### PR TITLE
Update to the latest plugins syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ For a full list of features see the [Buildkite Plugin Linter cli tool documentat
 steps:
   - label: ":sparkles: Lint"
     plugins:
-      plugin-linter#v2.0.0:
-        id: my-org/my-plugin
+      - plugin-linter#v2.0.0:
+          id: my-org/my-plugin
 ```
 
 Note: this will pull the latest version of the Plugin Linter each time it is run.


### PR DESCRIPTION
The recommended way to specify plugins in pipeline.yml files is as arrays. This updates the plugin linter’s own example to use this new format.

- [x] buildkite-plugins/buildkite-plugin-linter#155