### PR TITLE
Update linter image tag

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -7,7 +7,7 @@ if [ -z "${BUILDKITE_PLUGIN_PLUGIN_LINTER_ID:-}" ]; then
     exit 1
 fi
 
-TAG=${BUILDKITE_PLUGIN_PLUGIN_LINTER_IMAGE_VERSION:-v2.0.3}
+TAG=${BUILDKITE_PLUGIN_PLUGIN_LINTER_IMAGE_VERSION:-v2.0.4}
 
 echo "--- :docker: Fetching buildkite/plugin-linter:${TAG}"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -52,8 +52,8 @@ setup() {
   unset BUILDKITE_PLUGIN_PLUGIN_LINTER_IMAGE_VERSION
 
   stub docker \
-    "pull buildkite/plugin-linter:v2.0.3 : echo pulled image" \
-    "run -it --rm --volume /plugin:/plugin:ro --env PLUGIN_ID=my-plugin buildkite/plugin-linter:v2.0.3 : echo linted"
+    "pull buildkite/plugin-linter:v2.0.4 : echo pulled image" \
+    "run -it --rm --volume /plugin:/plugin:ro --env PLUGIN_ID=my-plugin buildkite/plugin-linter:v2.0.4 : echo linted"
 
   run "$PWD"/hooks/command
 


### PR DESCRIPTION
We did a new release on the Linter https://github.com/buildkite-plugins/buildkite-plugin-linter/releases/tag/v2.0.4 we need to update BUILDKITE_PLUGIN_PLUGIN_LINTER_IMAGE_VERSION to match that release.